### PR TITLE
Fix a tiny [#endif] error

### DIFF
--- a/UVC4UnityAndroid/Assets/UVC4UnityAndroidPlugin/Scripts/AndroidUtils.cs
+++ b/UVC4UnityAndroid/Assets/UVC4UnityAndroidPlugin/Scripts/AndroidUtils.cs
@@ -326,8 +326,8 @@ namespace Serenegiant
 			}
 		}
 
+#endif // #if UNITY_ANDROID
+
 	} // class AndroidUtils
 
 } // namespace Serenegiant
-
-#endif // #if UNITY_ANDROID


### PR DESCRIPTION
Braces errors are reported in PC, Mac & Linux mode. 
It doesn't work in PC mode anyway, so why bother with it?